### PR TITLE
Add a validation for the presence of the minor part in the version

### DIFF
--- a/StylesLoader.php
+++ b/StylesLoader.php
@@ -133,12 +133,15 @@ class StylesLoader {
 		// Array containing version number target order.
 		$version_targets = array();
 
-		// Build and push minor version numbers to targets array.
-		for ( $minor_version = 0; $minor_version <= $version_parts[2]; $minor_version++ ) {
-			array_push(
-				$version_targets,
-				implode( '.', array( $version_parts[0], $version_parts[1], $minor_version ) )
-			);
+		// If the current version has a minor part (the betas and RCs don't have one)
+		if ( array_key_exists( 2, $version_parts )) {
+			// Build and push minor version numbers to targets array.
+			for ($minor_version = 0; $minor_version <= $version_parts[2]; $minor_version++) {
+				array_push(
+					$version_targets,
+					implode('.', array($version_parts[0], $version_parts[1], $minor_version))
+				);
+			}
 		}
 
 		// Sort in reverse order so the latest minor version is first.


### PR DESCRIPTION
### Description
When executing this code on betas or RCs version, there is not necessarily a minor part in the version, so there was a warning message that shown (and made all the Cypress tests fail when testing with 6.0-beta2 ;) )

### Screenshots
Before : 
<img width="899" alt="Screen Shot 2022-04-24 at 22 55 52" src="https://user-images.githubusercontent.com/85255688/165013207-c2745006-be56-4233-90e2-cccbcfe83518.png">

After :
<img width="899" alt="Screen Shot 2022-04-24 at 22 56 57" src="https://user-images.githubusercontent.com/85255688/165013324-12338606-f2de-469d-bf08-b254b85d683c.png">